### PR TITLE
feat: allowing custom env variables in runtime

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,6 @@
 // load configuration file defined at NODE_ENV variable
+const fs = require('fs');
+
 const cwd = process.cwd();
 const env = process.env.NODE_ENV || 'default';
 
@@ -8,4 +10,16 @@ const config = isFramework ? require(`${cwd}/config/env/${env}`) : require(`${cw
 // inject app.env property
 if (config.app) config.app.env = env;
 
-module.exports = config;
+function getCustomEnv(_config) {
+    const customEnvExists = fs.existsSync(`${cwd}/api/config/custom-env.js`);
+    if (customEnvExists) {
+        const customEnv = require(`${cwd}/api/config/custom-env`);
+        return customEnv(_config);
+    }
+
+    return {};
+}
+
+const appConfig = { ...config, ...getCustomEnv(config) };
+
+module.exports = appConfig;


### PR DESCRIPTION
Para reproduzir, cria o arquivo em `api/config/custom-env.js` com o conteudo

```
module.exports = (config) => {
    const {
        SOME_VAR
    } = process.env;

    return {
        SOME_VAR,
        share: {
            exames: {
                ttl: 999999999999
            }
        }
    };
};
```

Inicia a aplicacao assim `SOME_VAR=some-value npm start`