### PR TITLE
feat: adicionando o conceito de arquivo .snf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 package-lock.json
 npm-debug.log
 _sandbox/logs/*.log*
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1324,3 +1324,24 @@ Than you can use you sampleError:
 ## Test
 
 SNF provides some test facilities especially if you are using SNF by an [create-snf-app](https://github.com/diogolmenezes/create-snf-app) application.
+
+## .snf file
+
+The configuration file with the lesser precedence importance is the `.snf` file. It must be created in the root of the parent project and might contain any data applicable in the environment files.
+
+The data written in the `.snf` file are overwritten by the data in the environment files, but are read first.
+
+## SNF with Typescript
+
+Apart from installing the Typescript dependencies, for exemple, `ts-node` and `typescript` libraries, 
+you can use Typescript in the parent project with very few configuration.
+
+If you are going to transpile all TS files in a directory other than the root folder, you must create a `.snf` file and add a `dir` property pointing to the correct location. 
+
+For example, if the files are transpiled to `root/dist/`, then create the `.snf` file as following:
+
+```
+{
+    "dir": "dist/"
+}
+```

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+2.0.32
+ - [FEATURE] Adicionando o conceito de arquivo `.snf` e a variável "dir" para alterar a estrutura de diretórios padrão no framework
 2.0.31
  - [FEATURE] Incluindo suporte a variaveis de ambiente
 2.0.30

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-2.0.32
+2.1.0
  - [FEATURE] Adicionando o conceito de arquivo `.snf` e a variável "dir" para alterar a estrutura de diretórios padrão no framework
 2.0.31
  - [FEATURE] Incluindo suporte a variaveis de ambiente

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,25 +1,33 @@
 // load configuration file defined at NODE_ENV variable
 const fs = require('fs');
+const path = require('path');
 
 const cwd = process.cwd();
-const env = process.env.NODE_ENV || 'default';
+const manifestPath = path.join(cwd, '.snf');
+const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath)) : {};
 
+const appDir = manifest.dir || '';
+const configDir = path.join(cwd, appDir, 'api/config');
+
+const env = process.env.NODE_ENV || 'default';
 const isFramework = process.env.IS_FRAMEWORK;
-const config = isFramework ? require(`${cwd}/config/env/${env}`) : require(`${cwd}/api/config/env/${env}`);
+
+const config = isFramework ? require(`${cwd}/config/env/${env}`) : require(`${configDir}/env/${env}`);
 
 // inject app.env property
 if (config.app) config.app.env = env;
 
 function getCustomEnv(_config) {
-    const customEnvExists = fs.existsSync(`${cwd}/api/config/custom-env.js`);
+    // DEPRECATED? Use extensões JS no lugar.
+    const customEnvExists = fs.existsSync(`${configDir}/custom-env.js`);
     if (customEnvExists) {
-        const customEnv = require(`${cwd}/api/config/custom-env`);
+        const customEnv = require(`${configDir}/custom-env`);
         return customEnv(_config);
     }
 
     return {};
 }
 
-const appConfig = { ...config, ...getCustomEnv(config) };
+const appConfig = { ...manifest, ...config, ...getCustomEnv(config) };
 
 module.exports = appConfig;

--- a/lib/route.js
+++ b/lib/route.js
@@ -16,7 +16,7 @@ class Route extends Loggable {
 
     // importing routes for all the modules
     importModuleRoutes() {
-        this.glob.sync(path.join(process.cwd(), (config.dir || ''), 'api/modules/**/route.js')).forEach((file) => {
+        this.glob.sync(path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.js')).forEach((file) => {
             const moduleName = this.path.basename(this.path.dirname(file));
             this.log.debug(`Importing [${moduleName}] routes from [${file}]`);
             require(this.path.resolve(file)); // eslint-disable-line

--- a/lib/route.js
+++ b/lib/route.js
@@ -16,7 +16,7 @@ class Route extends Loggable {
 
     // importing routes for all the modules
     importModuleRoutes() {
-        this.glob.sync('api/modules/**/route.js').forEach((file) => {
+        this.glob.sync(path.join(process.cwd(), config.dir, 'api/modules/**/route.js')).forEach((file) => {
             const moduleName = this.path.basename(this.path.dirname(file));
             this.log.debug(`Importing [${moduleName}] routes from [${file}]`);
             require(this.path.resolve(file)); // eslint-disable-line

--- a/lib/route.js
+++ b/lib/route.js
@@ -16,7 +16,7 @@ class Route extends Loggable {
 
     // importing routes for all the modules
     importModuleRoutes() {
-        this.glob.sync(path.join(process.cwd(), config.dir, 'api/modules/**/route.js')).forEach((file) => {
+        this.glob.sync(path.join(process.cwd(), (config.dir || ''), 'api/modules/**/route.js')).forEach((file) => {
             const moduleName = this.path.basename(this.path.dirname(file));
             this.log.debug(`Importing [${moduleName}] routes from [${file}]`);
             require(this.path.resolve(file)); // eslint-disable-line

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-node-framework",
-    "version": "2.0.32",
+    "version": "2.1.0-beta.0",
     "keywords": [
         "basic",
         "simple",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "simple-node-framework",
-    "version": "2.0.31",
+    "version": "2.0.32",
     "keywords": [
         "basic",
         "simple",


### PR DESCRIPTION
Nesse PR criamos a noção de arquivo .snf, que seria o primeiro (e menos importante) arquivo na ordem de precedencia dos arquivos de configuração. Ele sempre está na raiz (CWD) do projeto.

A motivação foi fazer com que o FW lesse os arquivos de configuração e rotas a partir de pastas que não são as mesmas da estrutura original do FW.

Com isso podemos adicionar Typescript a aplicação e configurar para que o projeto seja transpilado para a pasta `/dist` , por exemplo, e o FW continua conseguindo resolver os caminhos.

O arquivo `.snf` é necessário pois sem ele, nesse momento da execução, nós ainda não sabemos onde estão os arquivos de configuração. A informação de que a pasta mudou não pode estar num local que o o FW não conhece.

Uma alternativa (não implementada) ao `.snf`é passar uma variável de ambiente.

### .snf
```
{
    "app": {
        "name": "am-estrutura-backend"
    },
    "dir": "dist/"
}
```