### PR TITLE
Adicionado verificação se é execução de teste

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,9 +2,13 @@
 const fs = require('fs');
 const path = require('path');
 
+const isTest = process.argv.some(argument => {
+    return argument.includes('mocha') || argument.includes('jest');
+});
+
 const cwd = process.cwd();
 const manifestPath = path.join(cwd, '.snf');
-const manifest = fs.existsSync(manifestPath) ? JSON.parse(fs.readFileSync(manifestPath)) : {};
+const manifest = fs.existsSync(manifestPath) && !isTest ? JSON.parse(fs.readFileSync(manifestPath)) : {};
 
 const appDir = manifest.dir || '';
 const configDir = path.join(cwd, appDir, 'api/config');


### PR DESCRIPTION
Essa implementação tem como propósito evitar de ter que efetuar o build na aplicação antes da execução de qualquer teste. Atualmente o build é necessário quando a aplicação está configurada com Typescript, e possui o arquivo '.snf'.