### PR TITLE
Adicionado importação de rotas declaradas em arquivos ts

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -16,13 +16,7 @@ class Route extends Loggable {
 
     // importing routes for all the modules
     importModuleRoutes() {
-        const filesJs = path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.js');
-        const filesTs = path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.ts');
-        const routeFiles = [
-            ...this.glob.sync(filesJs),
-            ...this.glob.sync(filesTs)
-        ];
-        routeFiles.forEach((file) => {
+        this.glob.sync(path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.+(js|ts)')).forEach((file) => {
             const moduleName = this.path.basename(this.path.dirname(file));
             this.log.debug(`Importing [${moduleName}] routes from [${file}]`);
             require(this.path.resolve(file)); // eslint-disable-line

--- a/lib/route.js
+++ b/lib/route.js
@@ -16,7 +16,13 @@ class Route extends Loggable {
 
     // importing routes for all the modules
     importModuleRoutes() {
-        this.glob.sync(path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.js')).forEach((file) => {
+        const filesJs = path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.js');
+        const filesTs = path.join(process.cwd(), (this.config.dir || ''), 'api/modules/**/route.ts');
+        const routeFiles = [
+            ...this.glob.sync(filesJs),
+            ...this.glob.sync(filesTs)
+        ];
+        routeFiles.forEach((file) => {
             const moduleName = this.path.basename(this.path.dirname(file));
             this.log.debug(`Importing [${moduleName}] routes from [${file}]`);
             require(this.path.resolve(file)); // eslint-disable-line


### PR DESCRIPTION
Com a implementação atual, não é possível executar testes de integração. Utilizando o ts-node/register, o arquivo 'ts' é convertido em 'js' em tempo de execução, dispensando o build. Com isso, o framework não cria as rotas dentro de um arquivo ts. A nova implementação permite a importação dos dois tipos de arquivos.