### PR TITLE
feat: add custom identifier to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If you turn of *debug* SNF will not output logs at your console, by default we t
 ```json
 "log": {
     "debug": true,
+    "requestIdentifier": "requestKey",
     "bunyan": {
         "name": "Application",
         "streams": [
@@ -175,6 +176,14 @@ All the logs will be automaticaly prefixed with module name, so if you write a l
 DEBUG My Sample Controller =>  Loading customer [diogo]
 DEBUG Customer Service =>  Loading customer [diogo]
 DEBUG Customer Repository =>  Loading customer [diogo]
+```
+
+### Define Request Identifier
+
+"request_id" is default identifier but you can define a custom request identifier like bellow.
+
+``` json
+"requestIdentifier": "requestKey"
 ```
 
 ### Request id in the log

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -1,4 +1,5 @@
 // this class has many helper methods
+const config = require('../config');
 class Helper {
     // replace params in a string
     // ex.: resolveURL('http://google.com/profile/:id', {':id': cpf })
@@ -18,8 +19,22 @@ class Helper {
         return output;
     }
 
-    // retrieves the restify request id and returns without the traces "-"
+    // retrieves the request_id from header or restify request id and returns without the traces "-"
     static requestId(req) {
+
+        const requestIdentifier = 'request_id';
+        const configRequestIdetifier = config.log.requestIdentifier;
+
+        if(configRequestIdetifier?.length > 0) {
+            requestIdentifier = configRequestIdetifier;
+        }
+
+        const requestId = req.headers[configRequestIdetifier];
+
+        if(requestId) {
+            return requestId;
+        }
+
         if (req && typeof req.id === 'function') {
             req.id();
             return req._id.replace(/-/g, '');

--- a/lib/util/helpers.js
+++ b/lib/util/helpers.js
@@ -21,17 +21,16 @@ class Helper {
 
     // retrieves the request_id from header or restify request id and returns without the traces "-"
     static requestId(req) {
-
-        const requestIdentifier = 'request_id';
+        let requestIdentifier = 'request_id';
         const configRequestIdetifier = config.log.requestIdentifier;
 
-        if(configRequestIdetifier?.length > 0) {
+        if (configRequestIdetifier?.length > 0) {
             requestIdentifier = configRequestIdetifier;
         }
 
-        const requestId = req.headers[configRequestIdetifier];
+        const requestId = req.headers[requestIdentifier];
 
-        if(requestId) {
+        if (requestId) {
             return requestId;
         }
 


### PR DESCRIPTION
Fala @diogolmenezes,
Cara, percebi que o request_id não está sendo utilizado quando enviamos o valor, isso faz  com que percamos o tracing entre as apis.
Acabei adicionando a possibilidade de usar um outro valor como identificador tbm, da uma avaliada aí, por favor.