### PR TITLE
Feat: adicionando parametros ao construtor dos middlewares

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -89,9 +89,9 @@ class Server extends Base {
         
         this.app.use(Authorization.parse);
 
-        this.app.use(this.middlewares.compression()); 
+        this.app.use(this.middlewares.compression(this.config.middlewares?.compression)); 
 
-        this.app.use(this.middlewares.bodyParser.json());
+        this.app.use(this.middlewares.bodyParser.json(this.config.middlewares?.bodyParser?.json));
 
         // enable the automatic request and response logs
         this.app.use(this.plugins.requestAndResponseLogger.write.bind(this.plugins.requestAndResponseLogger))


### PR DESCRIPTION
Passando parâmetros para os construtores dos middlewares na inicialização do Servidor. 
Para essa finalidade foi criado um objeto novo no arquivo de configuração que é opcional:

```
module.exports = {
    "app": {
        "name": "nome-projeto",
        "baseRoute": "/api",
        "port": 8090
    },
    "middlewares": {
        "bodyParser": {
            "json": { limit: '10mb' }
        }
    },
...
}
```