### PR TITLE
feat: show unresolved variables

### DIFF
--- a/lib/util/read-config-file.js
+++ b/lib/util/read-config-file.js
@@ -69,9 +69,11 @@ const readAndParseYamlConfigFile = (configFile) => {
     data = data.replaceAll('${' + key + '}', envs[key]);
   }
 
-  const hasUnresolvedVariable = /\$\{.*\}/gm;
-  if (hasUnresolvedVariable.test(data) && process.env.NODE_ENV !== 'testing') {
-    throw new Error(`Config has unresolved variable`);
+  const unresolvedVariables = data.match(/\$\{.*\}/gm);
+
+  if (unresolvedVariables?.length > 0 && process.env.NODE_ENV !== 'testing') {
+    const variables = unresolvedVariables.reduce((a, b) => {a.concat(', ', b)})
+    throw new Error(`Config has unresolved variable(s): ${variables}`);
   }
 
   return yaml.load(data);


### PR DESCRIPTION
Quando um número grande de variáveis são adicionadas fica difícil saber qual está faltando. Com esse ajuste o erro exibe quais são elas, deixando mais fácil a correção.

Exemplo de como fica o log:

![image](https://github.com/user-attachments/assets/7941cd1a-9668-4d66-aad0-58416fd05a04)
