### PR TITLE
feat: show unresolved variables

### DIFF
--- a/lib/util/read-config-file.js
+++ b/lib/util/read-config-file.js
@@ -72,7 +72,7 @@ const readAndParseYamlConfigFile = (configFile) => {
   const unresolvedVariables = data.match(/\$\{.*\}/gm);
 
   if (unresolvedVariables?.length > 0 && process.env.NODE_ENV !== 'testing') {
-    const variables = unresolvedVariables.reduce((a, b) => {a.concat(', ', b)})
+    const variables = unresolvedVariables.reduce((a, b) => a.concat(', ', b))
     throw new Error(`Config has unresolved variable(s): ${variables}`);
   }
 


### PR DESCRIPTION
Quando um número grande de variáveis são adicionadas fica difícil saber qual está faltando. Com esse ajuste o erro exibe quais são elas, deixando mais fácil a correção.

![image](https://github.com/user-attachments/assets/7941cd1a-9668-4d66-aad0-58416fd05a04)
